### PR TITLE
Couple of commits related to inheritance/partitioning

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -223,7 +223,7 @@ _copyModifyTable(const ModifyTable *from)
 	COPY_SCALAR_FIELD(exclRelRTI);
 	COPY_NODE_FIELD(exclRelTlist);
 	COPY_NODE_FIELD(mergeSourceTargetList);
-	COPY_NODE_FIELD(mergeActionList);
+	COPY_NODE_FIELD(mergeActionLists);
 
 	return newnode;
 }
@@ -2315,6 +2315,7 @@ _copyMergeAction(const MergeAction *from)
 	COPY_SCALAR_FIELD(override);
 	COPY_NODE_FIELD(qual);
 	COPY_NODE_FIELD(targetList);
+	COPY_NODE_FIELD(updateColnos);
 
 	return newnode;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -424,7 +424,7 @@ _outModifyTable(StringInfo str, const ModifyTable *node)
 	WRITE_UINT_FIELD(exclRelRTI);
 	WRITE_NODE_FIELD(exclRelTlist);
 	WRITE_NODE_FIELD(mergeSourceTargetList);
-	WRITE_NODE_FIELD(mergeActionList);
+	WRITE_NODE_FIELD(mergeActionLists);
 }
 
 static void
@@ -2223,7 +2223,7 @@ _outModifyTablePath(StringInfo str, const ModifyTablePath *node)
 	WRITE_NODE_FIELD(onconflict);
 	WRITE_INT_FIELD(epqParam);
 	WRITE_NODE_FIELD(mergeSourceTargetList);
-	WRITE_NODE_FIELD(mergeActionList);
+	WRITE_NODE_FIELD(mergeActionLists);
 }
 
 static void

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -1721,7 +1721,7 @@ _readModifyTable(void)
 	READ_UINT_FIELD(exclRelRTI);
 	READ_NODE_FIELD(exclRelTlist);
 	READ_NODE_FIELD(mergeSourceTargetList);
-	READ_NODE_FIELD(mergeActionList);
+	READ_NODE_FIELD(mergeActionLists);
 
 	READ_DONE();
 }

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -2758,7 +2758,7 @@ create_modifytable_plan(PlannerInfo *root, ModifyTablePath *best_path)
 							best_path->rowMarks,
 							best_path->onconflict,
 							best_path->mergeSourceTargetList,
-							best_path->mergeActionList,
+							best_path->mergeActionLists,
 							best_path->epqParam);
 
 	copy_generic_path_info(&plan->plan, &best_path->path);
@@ -6885,7 +6885,7 @@ make_modifytable(PlannerInfo *root, Plan *subplan,
 				 List *withCheckOptionLists, List *returningLists,
 				 List *rowMarks, OnConflictExpr *onconflict,
 				 List *mergeSourceTargetList,
-				 List *mergeActionList, int epqParam)
+				 List *mergeActionLists, int epqParam)
 {
 	ModifyTable *node = makeNode(ModifyTable);
 	List	   *fdw_private_list;
@@ -6956,7 +6956,7 @@ make_modifytable(PlannerInfo *root, Plan *subplan,
 	node->returningLists = returningLists;
 	node->rowMarks = rowMarks;
 	node->mergeSourceTargetList = mergeSourceTargetList;
-	node->mergeActionList = mergeActionList;
+	node->mergeActionLists = mergeActionLists;
 	node->epqParam = epqParam;
 
 	/*

--- a/src/backend/optimizer/prep/preptlist.c
+++ b/src/backend/optimizer/prep/preptlist.c
@@ -150,8 +150,10 @@ preprocess_targetlist(PlannerInfo *root)
 			if (action->commandType == CMD_INSERT)
 				action->targetList = expand_insert_targetlist(action->targetList,
 															  target_relation);
+			else if (action->commandType == CMD_UPDATE)
+				action->updateColnos =
+					extract_update_targetlist_colnos(action->targetList);
 		}
-
 	}
 
 	/*

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -3619,7 +3619,7 @@ create_lockrows_path(PlannerInfo *root, RelOptInfo *rel,
  * 'rowMarks' is a list of PlanRowMarks (non-locking only)
  * 'onconflict' is the ON CONFLICT clause, or NULL
  * 'epqParam' is the ID of Param for EvalPlanQual re-eval
- * 'mergeActionList' is a list of MERGE actions
+ * 'mergeActionLists' is a list of lists of MERGE actions (one per rel)
  */
 ModifyTablePath *
 create_modifytable_path(PlannerInfo *root, RelOptInfo *rel,
@@ -3633,7 +3633,7 @@ create_modifytable_path(PlannerInfo *root, RelOptInfo *rel,
 						List *withCheckOptionLists, List *returningLists,
 						List *rowMarks, OnConflictExpr *onconflict,
 						List *mergeSourceTargetList,
-						List *mergeActionList, int epqParam)
+						List *mergeActionLists, int epqParam)
 {
 	ModifyTablePath *pathnode = makeNode(ModifyTablePath);
 
@@ -3702,7 +3702,7 @@ create_modifytable_path(PlannerInfo *root, RelOptInfo *rel,
 	pathnode->onconflict = onconflict;
 	pathnode->epqParam = epqParam;
 	pathnode->mergeSourceTargetList = mergeSourceTargetList;
-	pathnode->mergeActionList = mergeActionList;
+	pathnode->mergeActionLists = mergeActionLists;
 
 	return pathnode;
 }

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1658,7 +1658,8 @@ typedef struct MergeAction
 	OverridingKind override;	/* OVERRIDING clause */
 	Node	   *qual;			/* transformed WHEN AND conditions */
 	CmdType		commandType;	/* INSERT/UPDATE/DELETE/DO NOTHING */
-	List	   *targetList;		/* the target list (of ResTarget) */
+	List	   *targetList;		/* the target list (of TargetEntry) */
+	List	   *updateColnos;	/* target attribute numbers of an UPDATE */
 } MergeAction;
 
 /* ----------------------

--- a/src/include/nodes/pathnodes.h
+++ b/src/include/nodes/pathnodes.h
@@ -1889,7 +1889,7 @@ typedef struct ModifyTablePath
 	OnConflictExpr *onconflict; /* ON CONFLICT clause, or NULL */
 	int			epqParam;		/* ID of Param for EvalPlanQual re-eval */
 	List	   *mergeSourceTargetList;
-	List	   *mergeActionList;	/* actions for MERGE */
+	List	   *mergeActionLists;	/* per-target-table lists of actions for MERGE */
 } ModifyTablePath;
 
 /*

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -240,7 +240,7 @@ typedef struct ModifyTable
 	Index		exclRelRTI;		/* RTI of the EXCLUDED pseudo relation */
 	List	   *exclRelTlist;	/* tlist of the EXCLUDED pseudo relation */
 	List	   *mergeSourceTargetList;
-	List	   *mergeActionList;	/* actions for MERGE */
+	List	   *mergeActionLists;	/* per-target-table lists of actions for MERGE */
 } ModifyTable;
 
 struct PartitionPruneInfo;		/* forward reference to struct below */

--- a/src/include/optimizer/pathnode.h
+++ b/src/include/optimizer/pathnode.h
@@ -277,7 +277,7 @@ extern ModifyTablePath *create_modifytable_path(PlannerInfo *root,
 												List *withCheckOptionLists, List *returningLists,
 												List *rowMarks, OnConflictExpr *onconflict,
 												List *mergeSourceTargetList,
-												List *mergeActionList, int epqParam);
+												List *mergeActionLists, int epqParam);
 extern LimitPath *create_limit_path(PlannerInfo *root, RelOptInfo *rel,
 									Path *subpath,
 									Node *limitOffset, Node *limitCount,


### PR DESCRIPTION
Just like an inherited update/delete does for items like withCheckOptions, returningList et al, I think that MERGE should also make per-child-relation copies of mergeActionList and put them in ModifyTable.mergeActionList"s", with planner already having done the necessary translations needed to make the expressions refer to child relation attribute numbers.  That still leaves the child result relations that the planner doesn't open, that is, those that are only opened during execution via tuple routing, for which there IS some new code in ExecInitPartitionInfo(), but we might need to rethink some portions of it.  Like it'd be a good idea to be sure that we can remove "elog(WARNING, "this might need work")". :)

Also, I found that tuple routing that ExecMergeNotMatched() invokes can fail due to being fed a tuple that doesn't match the target relation tuple descriptor.  Without doing the ExecProject(action->rmas_proj), the slot passed to that function matched the output descriptor of the planSlot in ExecModifyTable(), which is no good as a tuple to begin tuple routing.  That's fixed in the 2nd commit.