### PR TITLE
Fix for merge-update.spec isolation test failures

### DIFF
--- a/src/test/isolation/expected/merge-update.out
+++ b/src/test/isolation/expected/merge-update.out
@@ -189,16 +189,18 @@ step pa_merge2a:
 step c1: COMMIT;
 step pa_merge2a: <... completed>
 step pa_select2: SELECT * FROM pa_target;
-key            val            
+key|val                                               
+---+--------------------------------------------------
+  2|initial                                           
+  2|initial updated by pa_merge1 updated by pa_merge2a
+(2 rows)
 
-2              initial        
-2              initial updated by pa_merge1 updated by pa_merge2a
 step c2: COMMIT;
 
 starting permutation: pa_merge2 pa_merge2a c1 pa_select2 c2
 step pa_merge2: 
   MERGE INTO pa_target t
-  USING (SELECT 1 as key, 'pa_merge1' as val) s
+  USING (SELECT 1 as key, 'pa_merge2' as val) s
   ON s.key = t.key
   WHEN NOT MATCHED THEN
 	INSERT VALUES (s.key, s.val)
@@ -216,7 +218,7 @@ step pa_merge2a:
  <waiting ...>
 step c1: COMMIT;
 step pa_merge2a: <... completed>
-error in steps c1 pa_merge2a: ERROR:  tuple to be deleted was already moved to another partition due to concurrent update
+ERROR:  tuple to be locked was already moved to another partition due to concurrent update
 step pa_select2: SELECT * FROM pa_target;
 ERROR:  current transaction is aborted, commands ignored until end of transaction block
 step c2: COMMIT;
@@ -224,7 +226,7 @@ step c2: COMMIT;
 starting permutation: pa_merge2 c1 pa_merge2a pa_select2 c2
 step pa_merge2: 
   MERGE INTO pa_target t
-  USING (SELECT 1 as key, 'pa_merge1' as val) s
+  USING (SELECT 1 as key, 'pa_merge2' as val) s
   ON s.key = t.key
   WHEN NOT MATCHED THEN
 	INSERT VALUES (s.key, s.val)
@@ -246,7 +248,7 @@ key|val
 ---+----------------------------
   1|pa_merge2a                  
   2|initial                     
-  2|initial updated by pa_merge1
+  2|initial updated by pa_merge2
 (3 rows)
 
 step c2: COMMIT;

--- a/src/test/isolation/specs/merge-update.spec
+++ b/src/test/isolation/specs/merge-update.spec
@@ -58,7 +58,7 @@ step "pa_merge1"
 step "pa_merge2"
 {
   MERGE INTO pa_target t
-  USING (SELECT 1 as key, 'pa_merge1' as val) s
+  USING (SELECT 1 as key, 'pa_merge2' as val) s
   ON s.key = t.key
   WHEN NOT MATCHED THEN
 	INSERT VALUES (s.key, s.val)


### PR DESCRIPTION
ExecCrossPartitionUpdate() doesn't appear to work correctly
when called as part of an MERGE update action.  The fix is to
let ExecDelete() that runs as part of a cross-partition update
do the necessary EvalPlanQual() check instead of relying on
the caller ExecMergeMatched()'s code to do so, because that
doesn't quite work.

ExecCrossPartitionUpdate() projects the "retry" tuple that must be
returned to ExecUpdate() using the MERGE action info, instead of
the regular update projection.