### PR TITLE
A few commits to improve the concurrent MERGE situation

### DIFF
--- a/src/backend/executor/execPartition.c
+++ b/src/backend/executor/execPartition.c
@@ -944,8 +944,7 @@ ExecInitPartitionInfo(ModifyTableState *mtstate, EState *estate,
 									RelationGetForm(partrel)->reltype,
 									&found_whole_row);
 			action_state->mas_whenqual =
-				ExecInitQual(make_ands_implicit((Expr *) action->qual),
-							 &mtstate->ps);
+				ExecInitQual((List *) action->qual, &mtstate->ps);
 		}
 	}
 	MemoryContextSwitchTo(oldcxt);

--- a/src/test/isolation/expected/merge-update.out
+++ b/src/test/isolation/expected/merge-update.out
@@ -189,12 +189,11 @@ step pa_merge2a:
 step c1: COMMIT;
 step pa_merge2a: <... completed>
 step pa_select2: SELECT * FROM pa_target;
-key|val                         
----+----------------------------
-  1|initial updated by pa_merge1
-  1|pa_merge2a                  
-  2|initial                     
-(3 rows)
+key|val                                               
+---+--------------------------------------------------
+  2|initial                                           
+  2|initial updated by pa_merge1 updated by pa_merge2a
+(2 rows)
 
 step c2: COMMIT;
 
@@ -219,14 +218,9 @@ step pa_merge2a:
  <waiting ...>
 step c1: COMMIT;
 step pa_merge2a: <... completed>
+ERROR:  tuple to be locked was already moved to another partition due to concurrent update
 step pa_select2: SELECT * FROM pa_target;
-key|val                         
----+----------------------------
-  1|pa_merge2a                  
-  2|initial                     
-  2|initial updated by pa_merge2
-(3 rows)
-
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
 step c2: COMMIT;
 
 starting permutation: pa_merge2 c1 pa_merge2a pa_select2 c2

--- a/src/test/isolation/expected/merge-update.out
+++ b/src/test/isolation/expected/merge-update.out
@@ -252,3 +252,63 @@ key|val
 (3 rows)
 
 step c2: COMMIT;
+
+starting permutation: pa_merge3 pa_merge2b_when c1 pa_select2 c2
+step pa_merge3: 
+  MERGE INTO pa_target t
+  USING (SELECT 1 as key, 'pa_merge2' as val) s
+  ON s.key = t.key
+  WHEN NOT MATCHED THEN
+	INSERT VALUES (s.key, s.val)
+  WHEN MATCHED THEN
+    UPDATE set val = 'prefix ' || t.val;
+
+step pa_merge2b_when: 
+  MERGE INTO pa_target t
+  USING (SELECT 1 as key, 'pa_merge2b_when' as val) s
+  ON s.key = t.key
+  WHEN NOT MATCHED THEN
+	INSERT VALUES (s.key, s.val)
+  WHEN MATCHED AND t.val like 'initial%' THEN
+	UPDATE set key = t.key + 1, val = t.val || ' updated by ' || s.val;
+ <waiting ...>
+step c1: COMMIT;
+step pa_merge2b_when: <... completed>
+step pa_select2: SELECT * FROM pa_target;
+key|val           
+---+--------------
+  1|prefix initial
+  2|initial       
+(2 rows)
+
+step c2: COMMIT;
+
+starting permutation: pa_merge1 pa_merge2b_when c1 pa_select2 c2
+step pa_merge1: 
+  MERGE INTO pa_target t
+  USING (SELECT 1 as key, 'pa_merge1' as val) s
+  ON s.key = t.key
+  WHEN NOT MATCHED THEN
+	INSERT VALUES (s.key, s.val)
+  WHEN MATCHED THEN
+    UPDATE set val = t.val || ' updated by ' || s.val;
+
+step pa_merge2b_when: 
+  MERGE INTO pa_target t
+  USING (SELECT 1 as key, 'pa_merge2b_when' as val) s
+  ON s.key = t.key
+  WHEN NOT MATCHED THEN
+	INSERT VALUES (s.key, s.val)
+  WHEN MATCHED AND t.val like 'initial%' THEN
+	UPDATE set key = t.key + 1, val = t.val || ' updated by ' || s.val;
+ <waiting ...>
+step c1: COMMIT;
+step pa_merge2b_when: <... completed>
+step pa_select2: SELECT * FROM pa_target;
+key|val                                                    
+---+-------------------------------------------------------
+  2|initial                                                
+  2|initial updated by pa_merge1 updated by pa_merge2b_when
+(2 rows)
+
+step c2: COMMIT;

--- a/src/test/isolation/expected/merge-update.out
+++ b/src/test/isolation/expected/merge-update.out
@@ -189,11 +189,12 @@ step pa_merge2a:
 step c1: COMMIT;
 step pa_merge2a: <... completed>
 step pa_select2: SELECT * FROM pa_target;
-key|val                                               
----+--------------------------------------------------
-  2|initial                                           
-  2|initial updated by pa_merge1 updated by pa_merge2a
-(2 rows)
+key|val                         
+---+----------------------------
+  1|initial updated by pa_merge1
+  1|pa_merge2a                  
+  2|initial                     
+(3 rows)
 
 step c2: COMMIT;
 
@@ -218,9 +219,14 @@ step pa_merge2a:
  <waiting ...>
 step c1: COMMIT;
 step pa_merge2a: <... completed>
-ERROR:  tuple to be locked was already moved to another partition due to concurrent update
 step pa_select2: SELECT * FROM pa_target;
-ERROR:  current transaction is aborted, commands ignored until end of transaction block
+key|val                         
+---+----------------------------
+  1|pa_merge2a                  
+  2|initial                     
+  2|initial updated by pa_merge2
+(3 rows)
+
 step c2: COMMIT;
 
 starting permutation: pa_merge2 c1 pa_merge2a pa_select2 c2


### PR DESCRIPTION
I noticed that a fix I earlier pushed to get cross-partition update test cases to produce sane output may have been ill-conceived.  By letting ExecDelete() part of a cross-partition update handle EvalPlanQual() as that commit did, we'd let a concurrently updated tuple that no longer satisfies the WHEN conditions (if any) of the action being executed to be successfully carried out.  We should really make the cross-partition updates behave just like non-cross-partition updates in that EvalPlanQual() on encountering a concurrent update is deferred to the caller, ExecMergeMatched(), which checks the latest tuple in the update chain against both the plan (what EvalPlanQual() itself does) and then also checks the actions' WHEN quals to execute the correct one for the updated tuple.

1st commit is to fix an unexpected error I got with some test case.

2nd reverts the earlier problematic commit I mentioned above.

3rd fixes how ExecMergeMatched() does EvalPlanQual() -- it now performs EvalPlanQual() with the latest tuple in the update chain as other sites that handle concurrent updates do, not the tuple found in ri_newTupleSlot.

4th adds a test case to exercise cross-partition-updates encountering concurrent updates that modify the tuple such that the originally satisfies WHEN condition is no longer.